### PR TITLE
runtime: ignore error returned by PowerRegisterSuspendResumeNotification

### DIFF
--- a/src/runtime/os_windows.go
+++ b/src/runtime/os_windows.go
@@ -294,9 +294,7 @@ func loadOptionalSyscalls() {
 
 func monitorSuspendResume() {
 	const (
-		_DEVICE_NOTIFY_CALLBACK   = 2
-		_ERROR_FILE_NOT_FOUND     = 2
-		_ERROR_INVALID_PARAMETERS = 87
+		_DEVICE_NOTIFY_CALLBACK = 2
 	)
 	type _DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS struct {
 		callback uintptr
@@ -323,25 +321,8 @@ func monitorSuspendResume() {
 		callback: compileCallback(*efaceOf(&fn), true),
 	}
 	handle := uintptr(0)
-	ret := stdcall3(powerRegisterSuspendResumeNotification, _DEVICE_NOTIFY_CALLBACK,
+	stdcall3(powerRegisterSuspendResumeNotification, _DEVICE_NOTIFY_CALLBACK,
 		uintptr(unsafe.Pointer(&params)), uintptr(unsafe.Pointer(&handle)))
-	// This function doesn't use GetLastError(), so we use the return value directly.
-	switch ret {
-	case 0:
-		return // Successful, nothing more to do.
-	case _ERROR_FILE_NOT_FOUND:
-		// Systems without access to the suspend/resume notifier
-		// also have their clock on "program time", and therefore
-		// don't want or need this anyway.
-		return
-	case _ERROR_INVALID_PARAMETERS:
-		// This is seen when running in Windows Docker.
-		// See issue 36557.
-		return
-	default:
-		println("runtime: PowerRegisterSuspendResumeNotification failed with errno=", ret)
-		throw("runtime: PowerRegisterSuspendResumeNotification failure")
-	}
 }
 
 //go:nosplit


### PR DESCRIPTION
It appears that PowerRegisterSuspendResumeNotification is not supported
when running inside Docker - see issues #35447, #36557 and #37149.

Our current code relies on error number to determine Docker environment.
But we already saw PowerRegisterSuspendResumeNotification return
ERROR_FILE_NOT_FOUND, ERROR_INVALID_PARAMETERS and ERROR_ACCESS_DENIED
(see issues above). So this approach is not sustainable.

Just ignore PowerRegisterSuspendResumeNotification returned error.

Fixes #37149

Change-Id: I2beba9d45cdb8c1efac5e974e747827a6261915a
Reviewed-on: https://go-review.googlesource.com/c/go/+/219657
Run-TryBot: Alex Brainman <alex.brainman@gmail.com>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Austin Clements <austin@google.com>
Reviewed-by: Jason A. Donenfeld <Jason@zx2c4.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
